### PR TITLE
Fix: Final carousel, button, and style corrections

### DIFF
--- a/luisnavasproducciones/assets/css/custom.css
+++ b/luisnavasproducciones/assets/css/custom.css
@@ -22,3 +22,13 @@
 .text-center {
     text-align: center;
 }
+
+.events-section, .events-page-section {
+    background: var(--black);
+}
+
+/* Force hero button visibility */
+.hero-text-slide .btn-primary {
+    opacity: 1 !important;
+    visibility: visible !important;
+}

--- a/luisnavasproducciones/eventos.php
+++ b/luisnavasproducciones/eventos.php
@@ -8,7 +8,7 @@ $stmt->execute();
 $eventos = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 
-<div class="section">
+<div class="section events-page-section">
     <div class="container">
         <div class="page-title text-center" style="padding: 60px 0; background: var(--dark-gray); border-radius: 12px;">
             <h1 class="hero-title">Todos Nuestros Eventos</h1>

--- a/luisnavasproducciones/index.php
+++ b/luisnavasproducciones/index.php
@@ -19,7 +19,7 @@ $eventos_grid = $stmt_eventos_grid->fetchAll(PDO::FETCH_ASSOC);
         <div class="hero-content-wrapper">
             <?php if (!empty($hero_eventos)): ?>
                 <?php foreach($hero_eventos as $index => $evento): ?>
-                    <div class="hero-text-slide">
+                    <div class="hero-text-slide text-center">
                         <h1 class="hero-title"><?php echo htmlspecialchars($evento['nombre']); ?></h1>
                         <p class="hero-subtitle"><?php echo substr(htmlspecialchars($evento['descripcion']), 0, 150); ?>...</p>
                         <div class="hero-event-meta">
@@ -32,7 +32,7 @@ $eventos_grid = $stmt_eventos_grid->fetchAll(PDO::FETCH_ASSOC);
                                 <span><?php echo htmlspecialchars($evento['ciudad']); ?></span>
                             </div>
                         </div>
-                        <a href="/evento/<?php echo htmlspecialchars($evento['slug']); ?>" class="hero-info-link">Más información</a>
+                        <a href="/evento/<?php echo htmlspecialchars($evento['slug']); ?>" class="btn btn-primary">Más información</a>
                     </div>
                 <?php endforeach; ?>
             <?php else: ?>


### PR DESCRIPTION
This commit implements the definitive fixes for the hero carousel and related styles based on user feedback.

- Restores the black background for the events section.
- Restores the use of buttons for all "Más información" links.
- Centers all text content within the hero carousel slides.
- Forces the hero carousel button to be visible at all times with a CSS `!important` rule, overriding any conflicting styles from the animation library.